### PR TITLE
Assume rspec1 if RSpec::Core is not defined

### DIFF
--- a/lib/rspec_candy/switcher.rb
+++ b/lib/rspec_candy/switcher.rb
@@ -3,7 +3,7 @@ module RSpecCandy
     extend self
 
     def rspec_version
-      if defined?(RSpec)
+      if defined?(RSpec::Core)
         :rspec2
       elsif defined?(Spec)
         :rspec1

--- a/spec/rspec1/switcher_spec.rb
+++ b/spec/rspec1/switcher_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe RSpecCandy::Switcher do
+  describe "#rspec_version" do
+    it "detects rspec1" do
+      RSpecCandy::Switcher.rspec_version.should == :rspec1
+    end
+
+    it "detects rspec1 when RSpec is defined" do
+      module ::RSpec
+      end
+      RSpecCandy::Switcher.rspec_version.should == :rspec1
+    end
+  end
+end


### PR DESCRIPTION
This avoids wrong version detection when RSpec
is defined but rspec 1 is loaded, not rspec 2. For example when
RSpec::Instafail is defined, from rspec-instafail gem
