### PR TITLE
Make it_should_run_callbacks work with custom state_machine names

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ If you only care about the matchers or helpers you can also more specifically re
       it_should_run_callbacks :notify_this, :notify_that
     end
 
+
+  If you have used a custom state machine name, you can use specify it like this:
+
+    describe Model, '#my_event on :my_machine from :my_state1 to :my_state" do
+      it_should_run_callbacks :notify_this, :notify_that
+    end
+
 **it_should_run_callbacks_in_order**
 
   Like `it_should_run_callbacks`, but also checks the correct order.

--- a/lib/rspec_candy/helpers/rails/it_should_run_callbacks.rb
+++ b/lib/rspec_candy/helpers/rails/it_should_run_callbacks.rb
@@ -88,11 +88,12 @@ module RSpecCandy
           end
 
           def run_state_machine_callbacks_from_prose(prose)
-            if parts = prose.match(/^(#\w+) from ([\:\w]+) to ([\:\w]+)$/)
+            if parts = prose.match(/^(#\w+) (?:on ([\:\w]+) )?from ([\:\w]+) to ([\:\w]+)$/)
               name = parts[1].sub(/^#/, '').to_sym
-              from = parts[2].sub(/^:/, '').to_sym
-              to = parts[3].sub(/^:/, '').to_sym
-              transition = StateMachine::Transition.new(subject, subject.class.state_machine, name, from, to)
+              machine_name = parts[2] ? parts[2].sub(/^:/, '').to_sym : :state
+              from = parts[3].sub(/^:/, '').to_sym
+              to = parts[4].sub(/^:/, '').to_sym
+              transition = StateMachine::Transition.new(subject, subject.class.state_machine(machine_name), name, from, to)
               transition.run_callbacks
             end
           end

--- a/spec/shared/app_root/app/models/state_machine_model.rb
+++ b/spec/shared/app_root/app/models/state_machine_model.rb
@@ -22,7 +22,30 @@ class StateMachineModel < ActiveRecord::Base
 
     end
 
+    state_machine :custom_state, :initial => :state1 do
+
+      state :state1
+
+      state :state2
+
+      state :state3
+
+      event :event do
+        transition :state1 => :state2
+      end
+
+      event :another_event do
+        transition :state1 => :state3
+      end
+
+      after_transition :state1 => :state2, :do => :custom_state_event_callback
+
+    end
+
     def event_callback
+    end
+
+    def custom_state_event_callback
     end
 
   end

--- a/spec/shared/rspec_candy/helpers/rails/it_should_run_callbacks_spec.rb
+++ b/spec/shared/rspec_candy/helpers/rails/it_should_run_callbacks_spec.rb
@@ -95,6 +95,22 @@ describe RSpecCandy::Helpers::Rails::ItShouldRunCallbacks do
         describe_block
       end
 
+      it 'should also run state machine callbacks for a state machine with a custom name and pass if they are called if StateMachine is present' do
+        <<-describe_block.should pass_as_describe_block
+          describe StateMachineModel, '#event on :custom_state from :state1 to :state2' do
+            it_should_run_callbacks :custom_state_event_callback
+          end
+        describe_block
+      end
+
+      it 'should also run state machine callbacks for a state machine with a custom name and fail if they are not called if StateMachine is present' do
+        <<-describe_block.should fail_as_describe_block
+          describe StateMachineModel, '#event on :custom_state from :state1 to :state3' do
+            it_should_run_callbacks :custom_state_event_callback
+          end
+        describe_block
+      end
+
     end
 
 


### PR DESCRIPTION
I needed this feature for something I'm working on, hopefully you'll consider it useful enough to merge in.

This is the first time I've submitted a pull request to a public repo, so apologies if there's anything I've not done correctly!
