### PR TITLE
Reverse RSpec version detection logic to start with RSpec2

### DIFF
--- a/lib/rspec_candy/switcher.rb
+++ b/lib/rspec_candy/switcher.rb
@@ -2,22 +2,16 @@ module RSpecCandy
   module Switcher
     extend self
 
-    # def rspec_version
-    #   if defined?(RSpec::Core)
-    #     :rspec2
-    #   elsif defined?(Spec)
-    #     :rspec1
-    #   else
-    #     raise 'Cannot determine RSpec version'
-    #   end
-    # end
-
     def rspec_version
-      if defined?(Spec)
-        1
-      else
+      begin
         require 'rspec/version'
         RSpec::Version::STRING.to_i
+      rescue LoadError
+        if defined?(Spec)
+          1
+        else
+          raise 'Cannot determine RSpec version'
+        end
       end
     end
 


### PR DESCRIPTION
Suggested fix for https://github.com/makandra/rspec_candy/issues/5.

Using `defined?(Spec)` to determine the version of rspec can lead to false positive if some other previously loaded code defined the `Spec` module. Since `require 'rspec/version'` has less chance of succeeding if rspec2 and over is not present, starting by this should make the detection more fail proof.