### PR TITLE
Prioritize pure ruby Hash methods over ActiveSupport-specific methods

### DIFF
--- a/lib/rspec_candy/matchers/include_hash.rb
+++ b/lib/rspec_candy/matchers/include_hash.rb
@@ -1,7 +1,7 @@
 RSpecCandy::Switcher.define_matcher :include_hash do |expected|
 
   match do |actual|
-    !actual.nil? && actual.slice(*expected.keys) == expected
+    !actual.nil? && expected.values == actual.values_at(*expected.keys)
   end
 
 end


### PR DESCRIPTION
I was just looking at this gem as a reference, and when I tried to borrow this matcher it failed without ActiveSupport. So I modified it a bit to be pure ruby using `values_at`, pretty much same level of complexity and no implicit Rails dependency (which, all else equal, should I think always be preferred).

See what you think. :smile: